### PR TITLE
greedy approximation speed-up

### DIFF
--- a/sume/ilp_models/concept_based.py
+++ b/sume/ilp_models/concept_based.py
@@ -355,26 +355,26 @@ class ConceptBasedILPSummarizer:
 
         """
 
-        # initialize the set of sentence indeces
-        sentence_indeces = set(range(0,len(self.sentences)))
+        # initialize the set of sentence indices
+        sentence_indices = set(range(0,len(self.sentences)))
 
-        # initialize the set of selected sentence indeces
-        selected_sentence_indeces = set()
+        # initialize the set of selected sentence indices in our greedy solution
+        selected_sentence_indices = set()
 
-        # initialize the concepts contained in G
+        # initialize the concepts contained in our greedy solution
         selected_concepts = set()
 
-        # initialize the size of the sentences in G
+        # initialize the length of our greedy solution
         selected_length = 0
 
-        # initialize the score of G
+        # initialize the score of our greedy solution
         selected_score = 0
 
         # greedily select a sentence
-        while sentence_indeces:
+        while sentence_indices:
 
             ####################################################################
-            # COMPUTE THE GAINS FOR EACH SENTENCE IN U
+            # COMPUTE THE GAINS FOR EACH SENTENCE LEFT
             ####################################################################
 
             best_sentence_index = None
@@ -385,7 +385,7 @@ class ConceptBasedILPSummarizer:
             best_score_delta = 0
 
             # loop through the set of sentences
-            for sentence_index in sentence_indeces:
+            for sentence_index in sentence_indices:
 
                 sentence = self.sentences[sentence_index]
 
@@ -418,7 +418,7 @@ class ConceptBasedILPSummarizer:
             if best_gain > 0:
 
                 # add the sentence index to the selected set
-                selected_sentence_indeces.add(best_sentence_index)
+                selected_sentence_indices.add(best_sentence_index)
 
                 # update the selected concepts
                 selected_concepts |= set(best_sentence.concepts)
@@ -430,13 +430,13 @@ class ConceptBasedILPSummarizer:
                 selected_score += best_score_delta
 
             # remove sentence index from indices
-            sentence_indeces.remove(sentence_index)
+            sentence_indices.remove(sentence_index)
 
         if best_singleton_score > selected_score:
             return best_singleton_score, set([best_singleton])
 
         # returns the (objective function value, solution) tuple
-        return selected_score, selected_sentence_indeces
+        return selected_score, selected_sentence_indices
 
 
     def greedy_approximation3(self, r=1.0, summary_size=100):
@@ -461,7 +461,7 @@ class ConceptBasedILPSummarizer:
         # initialize the score of the best singleton
         best_singleton_score = 0
 
-        # compute indeces of our sentences
+        # compute indices of our sentences
         sentences = range(len(self.sentences))
 
         # compute initial weights and fill the reverse index

--- a/sume/ilp_models/concept_based.py
+++ b/sume/ilp_models/concept_based.py
@@ -390,8 +390,9 @@ class ConceptBasedILPSummarizer:
                     continue
 
                 # compute the score difference if we add the sentence
-                u_score_delta = sum(self.weights[c] for c in
-                                    set(sentence.concepts) - G_concepts)
+                u_score_delta = sum(self.weights[c]
+                                    for c in sentence.concepts
+                                    if c not in G_concepts)
 
                 # compute the normalization of the score difference by
                 # the sentence length

--- a/sume/ilp_models/concept_based.py
+++ b/sume/ilp_models/concept_based.py
@@ -461,9 +461,12 @@ class ConceptBasedILPSummarizer:
         # initialize the score of the best singleton
         best_singleton_score = 0
 
+        # compute indeces of our sentences
+        sentences = range(len(self.sentences))
+
         # compute initial weights and fill the reverse index
         # while keeping track of the best singleton solution
-        for i in range(len(self.sentences)):
+        for i in sentences:
             weight = 0
             for concept in set(self.sentences[i].concepts):
                 c2s[concept].add(i)
@@ -477,8 +480,7 @@ class ConceptBasedILPSummarizer:
         selected_subset, selected_length, selected_score = set(), 0, 0
 
         # greedily select a sentence
-        sentences = range(len(self.sentences))
-        while sentences:
+        while True:
 
             ####################################################################
             # RETRIEVE THE BEST SENTENCE
@@ -494,19 +496,22 @@ class ConceptBasedILPSummarizer:
             # select the first sentence that fits in the length limit
             for sentence_gain, rev_length, sentence_index in sorted_gain:
                 if selected_length - rev_length <= summary_size:
-                    best_gain_index = sentence_index
                     break
             # if we don't find a sentence, break out of the main while loop
             else:
                 break
 
+            # if the gain is null, break out of the main while loop
+            if not weights[sentence_index]:
+                break
+
             # update the selected subset properties
-            selected_subset.add(best_gain_index)
-            selected_score += weights[best_gain_index]
-            selected_length += self.sentences[best_gain_index].length
+            selected_subset.add(sentence_index)
+            selected_score += weights[sentence_index]
+            selected_length += self.sentences[sentence_index].length
 
             # update sentence weights with the reverse index
-            for concept in set(self.sentences[best_gain_index].concepts):
+            for concept in set(self.sentences[sentence_index].concepts):
                 for sentence in c2s[concept]:
                     weights[sentence] -= self.weights[concept]
 


### PR DESCRIPTION
Here are the runtimes (first line is `greedy_approximation`, second is `greedy_approximation2`, third is `greedy_approximation3`):

```
$ python approximate_solution.py ../concept-based_ilp_summarization/data/tac2008/D0801A-A/ out.txt
info - 181 objective 0.01129 secs from file ../concept-based_ilp_summarization/data/tac2008/D0801A-A/
info - 181 objective 0.002916 secs from file ../concept-based_ilp_summarization/data/tac2008/D0801A-A/
info - 181 objective 0.001968 secs from file ../concept-based_ilp_summarization/data/tac2008/D0801A-A/
```
